### PR TITLE
Fixed a bug where inheritance causes objects to hash to the same value.

### DIFF
--- a/hashmap.js
+++ b/hashmap.js
@@ -129,7 +129,7 @@
 
 				default:
 					// TODO: Don't use expandos when Object.defineProperty is not available?
-					if (!key._hmuid_) {
+					if (!key.hasOwnProperty('_hmuid_')) {
 						key._hmuid_ = ++HashMap.uid;
 						hide(key, '_hmuid_');
 					}

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,7 @@ describe('hashmap', function() {
 			check(/test/, '/test/');
 			check(new Date(123456789), new Date(987654321));
 			check({}, {});
+			check(hashmap, Object.create(hashmap));
 		});
 	});
 


### PR DESCRIPTION
The hash value is currently inherited, which could cause problems if the prototype of some object also happens to have gone through the hashmap. The fix could also give a slight performance boost (hasOwnProperty won't walk the entire prototype chain). It shouldn't lead to any compatibility issues, as this is standard from JS 1.5 and is available in all JS environments.