### PR TITLE
Made count() an O(1) operation

### DIFF
--- a/hashmap.js
+++ b/hashmap.js
@@ -39,7 +39,11 @@
 
 		set:function(key, value) {
 			// Store original key as well (for iteration)
-			this._data[this.hash(key)] = [key, value];
+			var hash = this.hash(key);
+			if ( !(hash in this._data) ) {
+				this._count++;
+			}
+			this._data[hash] = [key, value];
 		},
 
 		multi:function() {
@@ -47,8 +51,11 @@
 		},
 
 		copy:function(other) {
-			for (var key in other._data) {
-				this._data[key] = other._data[key];
+			for (var hash in other._data) {
+				if ( !(hash in this._data) ) {
+					this._count++;
+				}
+				this._data[hash] = other._data[hash];
 			}
 		},
 
@@ -67,7 +74,11 @@
 		},
 
 		remove:function(key) {
-			delete this._data[this.hash(key)];
+			var hash = this.hash(key);
+			if ( hash in this._data ) {
+				this._count--;
+				delete this._data[hash];
+			}
 		},
 
 		type:function(key) {
@@ -93,12 +104,13 @@
 		},
 
 		count:function() {
-			return this.keys().length;
+			return this._count;
 		},
 
 		clear:function() {
 			// TODO: Would Object.create(null) make any difference
 			this._data = {};
+			this._count = 0;
 		},
 
 		clone:function() {


### PR DESCRIPTION
Background story: I found myself in situation where I have to build nested hashmaps to keep track of relations between objects in my app. They form a tree-like structure . The tricky part is to know when to remove a leaf. I need to remove a nested hashmap from its parent once it becomes empty, so that parent can deallocate it (probably causing a cascade into its parent if it also becomes empty, etc.). One way to do this is to check if the hashmap is empty after each remove operation. The problem is that implementation of `count()` was linear, which effectively causes each removal a linear operation in my scenario.

Solution: I see two ways of solving this.
A) adding an explicit `isEmpty()` operation which "simply" checks if `this._data` is empty. This in turn is not obvious how to do in O(1) time, as `this._data` is a simple js object. Moreover this would add a new function to the interface, which is probably not a decision taken lightly.
B) making count() work in O(1) time by maintaining the current `this._count` on each operation in O(1)

I like the later solution better, and here is my attempt at it.
This is my first pull request on github, so you are welcome to let me know if I did something wrong!