### PR TITLE
support ECMA 5 non-conformant behaviour of Microsoft edge

### DIFF
--- a/hashmap.js
+++ b/hashmap.js
@@ -85,8 +85,8 @@
 		type:function(key) {
 			var str = Object.prototype.toString.call(key);
 			var type = str.slice(8, -1).toLowerCase();
-			// Some browsers yield DOMWindow for null and undefined, works fine on Node
-			if (type === 'domwindow' && !key) {
+			// Some browsers yield DOMWindow or Window for null and undefined, works fine on Node
+			if (!key && (type === 'domwindow' || type === 'window')) {
 				return key + '';
 			}
 			return type;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hashmap",
   "author": "Ariel Flesler <aflesler@gmail.com>",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "HashMap Class for JavaScript",
   "keywords": [
     "hashmap",

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,24 @@ describe('hashmap', function() {
 			check(HashMap, 'function');
 			check(hashmap, 'object');
 		});
+
+        	it('should cast type for browsers that don\'t conform to ECMA 5 spec', function() {
+            		var originalToString = Object.prototype.toString;
+            		var type = 'DOMWindow';
+
+            		Object.prototype.toString = function() {
+                		return '[object ' + type + ']';
+            		};
+
+            		check(null, 'null');
+            		check(undefined, 'undefined');
+
+            		type = "Window";
+            		check(null, 'null');
+            		check(undefined, 'undefined');
+
+            		Object.prototype.toString = originalToString;
+        	});
 	});
 
 	describe('hashmap.hash()', function() {


### PR DESCRIPTION
Microsoft Edge does not conform to the ECMA 5 spec (http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.2).

toString of null returns [Object Window].

This patch fixes the issue and adds tests for these edge cases.