### PR TITLE
fix(type): some browsers return window

### DIFF
--- a/hashmap.js
+++ b/hashmap.js
@@ -85,8 +85,8 @@
 		type:function(key) {
 			var str = Object.prototype.toString.call(key);
 			var type = str.slice(8, -1).toLowerCase();
-			// Some browsers yield DOMWindow for null and undefined, works fine on Node
-			if (type === 'domwindow' && !key) {
+			// Some browsers yield DOMWindow or Window for null and undefined, works fine on Node
+			if (type === 'domwindow' || type === 'window' && !key) {
 				return key + '';
 			}
 			return type;


### PR DESCRIPTION
Some browsers return window as a type for null or undefined which will fail in the hash function since the switch case does not handle window type