### PR TITLE
Added entries()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,7 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `type(key:*) : String` returns the data type of the provided key (used internally)
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
+- `entries() : Array<[*,*]>` returns an array with [key,value] pairs
 - `count() : Number` returns the amount of key-value pairs
 - `clear() : HashMap` removes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original

--- a/hashmap.js
+++ b/hashmap.js
@@ -104,6 +104,13 @@
 			return values;
 		},
 
+		entries:function() {
+			var entries = [];
+			this.forEach(function(value, key) { entries.push([key, value]); });
+			return entries;
+		},
+
+
 		count:function() {
 			return this._count;
 		},

--- a/test/test.js
+++ b/test/test.js
@@ -288,6 +288,23 @@ describe('hashmap', function() {
 		});
 	});
 
+	describe('hashmap.entries()', function() {
+		it('should return an empty array for an empty hashmap', function() {
+			expect(hashmap.entries()).to.be.empty;
+		});
+
+		it('should return an array with one value once added', function() {
+			hashmap.set('key', 'value');
+			expect(hashmap.entries()).to.deep.equal([['key','value']]);
+		});
+
+		it('should work for several values', function() {
+			hashmap.set('key', 'value');
+			hashmap.set('key2', 'value2');
+			expect(hashmap.entries()).to.deep.equal([['key','value'], ['key2','value2']]);
+		});
+	});
+
 	describe('hashmap.count()', function() {
 		it('should return 0 when nothing was added', function() {
 			expect(hashmap.count()).to.equal(0);


### PR DESCRIPTION
As ES6 `Map` not only supports `.keys()` and `.values()` but also `.entries()` and the ES6 Maps can't replace `hashmap` for certain usecases (like array keys), I thought it would be nice to add `.entries()` to hashmap as well.

Rationale: It's really convenient to use with the new ES6 `for ... of` syntax, like this:
```js
let mymap = new HashMap()
// fill mymap here
for(let [key, value] of mymap.entries()) {
   // ...
}
```

This PR adds `.entries()` including unit test and some docs in the README.