### PR TITLE
Added delete() as alias for remove() (ES6 map compatibility)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,8 +40,8 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `copy(other:HashMap) : HashMap` copies all key-value pairs from other to this instance
 - `has(key:*) : Boolean` returns whether a key is set on the hashmap
 - `search(value:*) : *` returns key under which given value is stored (`null` if not found)
-- `remove(key:*) : HashMap` deletes a key-value pair by key
-- `delete(key:*) : HashMap` Alias for `remove(key:*)`
+- `delete(key:*) : HashMap` deletes a key-value pair by key
+- `remove(key:*) : HashMap` Alias for `delete(key:*)`
 - `type(key:*) : String` returns the data type of the provided key (used internally)
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,7 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `has(key:*) : Boolean` returns whether a key is set on the hashmap
 - `search(value:*) : *` returns key under which given value is stored (`null` if not found)
 - `remove(key:*) : HashMap` deletes a key-value pair by key
+- `delete(key:*) : HashMap` Alias for `remove(key:*)`
 - `type(key:*) : String` returns the data type of the provided key (used internally)
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values

--- a/Readme.md
+++ b/Readme.md
@@ -41,13 +41,13 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `has(key:*) : Boolean` returns whether a key is set on the hashmap
 - `search(value:*) : *` returns key under which given value is stored (`null` if not found)
 - `delete(key:*) : HashMap` deletes a key-value pair by key
-- `remove(key:*) : HashMap` Alias for `delete(key:*)`
+- `remove(key:*) : HashMap` Alias for `delete(key:*)` *(deprecated)*
 - `type(key:*) : String` returns the data type of the provided key (used internally)
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
 - `entries() : Array<[*,*]>` returns an array with [key,value] pairs
 - `count() : Number` returns the amount of key-value pairs
-- `clear() : HashMap` removes all the key-value pairs on the hashmap
+- `clear() : HashMap` deletes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original
 - `hash(key:*) : String` returns the stringified version of a key (used internally)
 - `forEach(function(value, key)) : HashMap` iterates the pairs and calls the function for each one
@@ -76,6 +76,15 @@ var HashMap = require('hashmap');
 map.set("some_key", "some value");
 map.get("some_key"); // --> "some value"
 ```
+
+### Deleting key-value pairs
+
+```js
+map.set("some_key", "some value");
+map.delete("some_key");
+map.get("some_key"); // --> undefined
+```
+
 ### No stringification
 
 ```js

--- a/hashmap.js
+++ b/hashmap.js
@@ -166,20 +166,21 @@
 		}
 	};
 
-	// ES6 Map API compatibility
-	HashMap.prototype.remove = HashMap.prototype.delete;
-
 	HashMap.uid = 0;
 
 	//- Add chaining to all methods that don't return something
 
-	['set','multi','copy','delete','remove','clear','forEach'].forEach(function(method) {
+	['set','multi','copy','delete','clear','forEach'].forEach(function(method) {
 		var fn = proto[method];
 		proto[method] = function() {
 			fn.apply(this, arguments);
 			return this;
 		};
 	});
+
+	//- Backwards compatibility
+
+	HashMap.prototype.remove = HashMap.prototype.delete;
 
 	//- Utils
 

--- a/hashmap.js
+++ b/hashmap.js
@@ -173,7 +173,7 @@
 
 	//- Add chaining to all methods that don't return something
 
-	['set','multi','copy','remove','clear','forEach'].forEach(function(method) {
+	['set','multi','copy','delete','remove','clear','forEach'].forEach(function(method) {
 		var fn = proto[method];
 		proto[method] = function() {
 			fn.apply(this, arguments);

--- a/hashmap.js
+++ b/hashmap.js
@@ -74,7 +74,7 @@
 			return null;
 		},
 
-		remove:function(key) {
+		delete:function(key) {
 			var hash = this.hash(key);
 			if ( hash in this._data ) {
 				this._count--;
@@ -167,7 +167,7 @@
 	};
 
 	// ES6 Map API compatibility
-	HashMap.prototype.delete = HashMap.prototype.remove;
+	HashMap.prototype.remove = HashMap.prototype.delete;
 
 	HashMap.uid = 0;
 

--- a/hashmap.js
+++ b/hashmap.js
@@ -82,6 +82,10 @@
 			}
 		},
 
+		delete:function(key) {
+			this.remove(key);
+		},
+
 		type:function(key) {
 			var str = Object.prototype.toString.call(key);
 			var type = str.slice(8, -1).toLowerCase();

--- a/hashmap.js
+++ b/hashmap.js
@@ -82,10 +82,6 @@
 			}
 		},
 
-		delete:function(key) {
-			this.remove(key);
-		},
-
 		type:function(key) {
 			var str = Object.prototype.toString.call(key);
 			var type = str.slice(8, -1).toLowerCase();
@@ -169,6 +165,9 @@
 			}
 		}
 	};
+
+	// ES6 Map API compatibility
+	HashMap.prototype.delete = HashMap.prototype.remove;
 
 	HashMap.uid = 0;
 

--- a/hashmap.js
+++ b/hashmap.js
@@ -180,6 +180,7 @@
 
 	//- Backwards compatibility
 
+	// TODO: remove() is deprecated and will be deleted in a future version
 	HashMap.prototype.remove = HashMap.prototype.delete;
 
 	//- Utils

--- a/test/test.js
+++ b/test/test.js
@@ -128,7 +128,7 @@ describe('hashmap', function() {
 	});
 
 	describe('hashmap.delete()', function() {
-		it('should remove an entry by key', function() {
+		it('should delete an entry by key', function() {
 			hashmap.set('key', 'value1');
 			hashmap.delete('key');
 			expect(hashmap.has('key')).to.be.false;
@@ -141,7 +141,7 @@ describe('hashmap', function() {
 	});
 
 	describe('hashmap.remove()', function() {
-		it('should remove an entry by key', function() {
+		it('should delete an entry by key', function() {
 			hashmap.set('key', 'value1');
 			hashmap.remove('key');
 			expect(hashmap.has('key')).to.be.false;

--- a/test/test.js
+++ b/test/test.js
@@ -142,15 +142,8 @@ describe('hashmap', function() {
 	});
 
 	describe('hashmap.remove()', function() {
-		it('should delete an entry by key', function() {
-			hashmap.set('key', 'value1');
-			hashmap.remove('key');
-			expect(hashmap.has('key')).to.be.false;
-		});
-
-		it('should not fail when the key is not found', function() {
-			hashmap.remove('key');
-			expect(hashmap.has('key')).to.be.false;
+		it('should be the same function as delete', function() {
+			expect(hashmap.remove).to.equal(hashmap.delete);
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,7 @@ describe('hashmap', function() {
 		it('should return the instance on some methods', function() {
 			expect(hashmap.set('key', 'value')).to.equal(hashmap);
 			expect(hashmap.multi()).to.equal(hashmap);
+			expect(hashmap.delete('key')).to.equal(hashmap);
 			expect(hashmap.remove('key')).to.equal(hashmap);
 			expect(hashmap.copy(hashmap)).to.equal(hashmap);
 			expect(hashmap.clear()).to.equal(hashmap);

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,19 @@ describe('hashmap', function() {
 		});
 	});
 
+	describe('hashmap.delete()', function() {
+		it('should delete an entry by key', function() {
+			hashmap.set('key', 'value1');
+			hashmap.delete('key');
+			expect(hashmap.has('key')).to.be.false;
+		});
+
+		it('should not fail when the key is not found', function() {
+			hashmap.delete('key');
+			expect(hashmap.has('key')).to.be.false;
+		});
+	});
+
 	describe('hashmap.remove()', function() {
 		it('should remove an entry by key', function() {
 			hashmap.set('key', 'value1');

--- a/test/test.js
+++ b/test/test.js
@@ -128,7 +128,7 @@ describe('hashmap', function() {
 	});
 
 	describe('hashmap.delete()', function() {
-		it('should delete an entry by key', function() {
+		it('should remove an entry by key', function() {
 			hashmap.set('key', 'value1');
 			hashmap.delete('key');
 			expect(hashmap.has('key')).to.be.false;

--- a/test/test.js
+++ b/test/test.js
@@ -240,9 +240,9 @@ describe('hashmap', function() {
 			expect(collect().length).to.equal(2);
 		});
 
-		it('should not call the callback on removed keys', function() {
+		it('should not call the callback on delete keys', function() {
 			hashmap.set('key', 'value');
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(collect()).to.be.empty;
 		});
 
@@ -334,13 +334,13 @@ describe('hashmap', function() {
 			expect(hashmap.count()).to.equal(2);
 		});
 
-		it('should decrease when removing a key', function() {
+		it('should decrease when deleting a key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value');
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(hashmap.count()).to.equal(1);
 
-			hashmap.remove('key2');
+			hashmap.delete('key2');
 			expect(hashmap.count()).to.equal(0);
 		});
 	});
@@ -351,13 +351,13 @@ describe('hashmap', function() {
 			expect(hashmap.count()).to.equal(0);
 		});
 
-		it('should remove the only entry', function() {
+		it('should delete the only entry', function() {
 			hashmap.set('key', 'value');
 			hashmap.clear();
 			expect(hashmap.count()).to.equal(0);
 		});
 
-		it('should remove multiple entries', function() {
+		it('should delete multiple entries', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value2');
 			hashmap.clear();


### PR DESCRIPTION
ES6 maps have a `delete()` instead of a `remove()` function, therefore I added `delete()` as an alias for `remove()`. No actually new code has been added, but I added a full unit test (copy of `remove()` unit test) anyway, just to be safe.

Note that there is (as far as I know) no way to achieve 100% compatibility as `Map.prototype.size` is a number whereas `HashMap.prototype.count` is a function. My goal is to get the best compatibility possible without changing anything major in HashMap for now.

