### PR TITLE
Added 2D key-value array constructor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 ## HashMap constructor overloads
 - `new HashMap()` creates an empty hashmap
 - `new HashMap(map:HashMap)` creates a hashmap with the key-value pairs of `map`
+- `new HashMap(arr:Array)` creates a hashmap from the 2D key-value array `arr`, e.g. `[['key1','val1'], ['key2','val2']]`
 - `new HashMap(key:*, value:*, key2:*, value2:*, ...)` creates a hashmap with several key-value pairs
 
 ## HashMap methods

--- a/hashmap.js
+++ b/hashmap.js
@@ -26,9 +26,11 @@
 		switch (arguments.length) {
 			case 0: break;
 			case 1: {
-				if(Array.isArray(other)) {
-					this.from2DArray(other);
-				} else {
+				if ('length' in other) {
+					// Flatten 2D array to alternating key-value array
+					multi(this, 
+						Array.prototype.concat.apply([], other));
+				} else { // Assumed to be a HashMap instance
 					this.copy(other);
 				}
 				break;
@@ -56,13 +58,6 @@
 
 		multi:function() {
 			multi(this, arguments);
-		},
-
-
-		from2DArray:function(arr) {
-			for (var i in arr) {
-				this.set(arr[i][0], arr[i][1]);
-			}
 		},
 
 		copy:function(other) {

--- a/hashmap.js
+++ b/hashmap.js
@@ -25,7 +25,14 @@
 		this.clear();
 		switch (arguments.length) {
 			case 0: break;
-			case 1: this.copy(other); break;
+			case 1: {
+				if(Array.isArray(other)) {
+					this.from2DArray(other);
+				} else {
+					this.copy(other);
+				}
+				break;
+			}
 			default: multi(this, arguments); break;
 		}
 	}
@@ -49,6 +56,13 @@
 
 		multi:function() {
 			multi(this, arguments);
+		},
+
+
+		from2DArray:function(arr) {
+			for (var i in arr) {
+				this.set(arr[i][0], arr[i][1]);
+			}
 		},
 
 		copy:function(other) {

--- a/hashmap.js
+++ b/hashmap.js
@@ -28,8 +28,7 @@
 			case 1: {
 				if ('length' in other) {
 					// Flatten 2D array to alternating key-value array
-					multi(this, 
-						Array.prototype.concat.apply([], other));
+					multi(this, Array.prototype.concat.apply([], other));
 				} else { // Assumed to be a HashMap instance
 					this.copy(other);
 				}

--- a/test/test.js
+++ b/test/test.js
@@ -441,6 +441,16 @@ describe('hashmap', function() {
 			expect(map.get('key2')).to.equal('value2');
 		});
 
+		it('should initialize from a 2D array for a single Array argument', function() {
+			var map = new HashMap(
+				[['key', 'value'],
+				 ['key2', 'value2']]
+			);
+			expect(map.count()).to.equal(2);
+			expect(map.get('key')).to.equal('value');
+			expect(map.get('key2')).to.equal('value2');
+		});
+
 		it('should initialize with pairs when several arguments', function() {
 			var map = new HashMap(
 				'key', 'value',

--- a/test/test.js
+++ b/test/test.js
@@ -451,6 +451,16 @@ describe('hashmap', function() {
 			expect(map.get('key2')).to.equal('value2');
 		});
 
+		it('should initialize from a 2D array for a nested Array argument', function() {
+			var map = new HashMap(
+				[[[1, 'key'], ['value', 1]],
+				 [[2, 'key2'], ['value2', 2]]]
+			);
+			expect(map.count()).to.equal(2);
+			expect(map.get([1, 'key'])).to.deep.equal(['value', 1]);
+			expect(map.get([2, 'key2'])).to.deep.equal(['value2', 2]);
+		});
+
 		it('should initialize with pairs when several arguments', function() {
 			var map = new HashMap(
 				'key', 'value',


### PR DESCRIPTION
As discussed in https://github.com/flesler/hashmap/pull/34 this adds a constructor variant
```js
new HashMap([['key1','val1'],['key2','val2']]);
```
for better ES6 map compatibility. Also adds README docs + unit test.

There should be no effect on backwards capability.

Regarding the usage of `Array.isArray`, this function has been supported in Chrome (=> V8) since 2010 and NodeJS v0.1.x was released in 2011, so I don't think this should be an issue, however I'd like to hear your thoughts. 