### PR TITLE
Add .size property for ES6 map compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,8 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
 - `entries() : Array<[*,*]>` returns an array with [key,value] pairs
-- `count() : Number` returns the amount of key-value pairs
+- `size : Number` returns the amount of key-value pairs
+- `count() : Number` alias for `size`
 - `clear() : HashMap` removes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original
 - `hash(key:*) : String` returns the stringified version of a key (used internally)
@@ -75,6 +76,17 @@ var HashMap = require('hashmap');
 map.set("some_key", "some value");
 map.get("some_key"); // --> "some value"
 ```
+
+### Map size
+
+```js
+var map = new HashMap();
+map.set("key1", "val1");
+map.set("key2", "val2");
+map.size; // -> 2
+map.count(); // Alias -> 2
+```
+
 ### No stringification
 
 ```js

--- a/Readme.md
+++ b/Readme.md
@@ -77,7 +77,7 @@ map.set("some_key", "some value");
 map.get("some_key"); // --> "some value"
 ```
 
-### Map size
+### Map size / number of elements
 
 ```js
 var map = new HashMap();

--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,8 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
 - `entries() : Array<[*,*]>` returns an array with [key,value] pairs
-- `size : Number` returns the amount of key-value pairs
-- `count() : Number` alias for `size`
+- `size : Number` the amount of key-value pairs
+- `count() : Number` returns the amount of key-value pairs *(deprecated)*
 - `clear() : HashMap` removes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original
 - `hash(key:*) : String` returns the stringified version of a key (used internally)
@@ -84,7 +84,6 @@ var map = new HashMap();
 map.set("key1", "val1");
 map.set("key2", "val2");
 map.size; // -> 2
-map.count(); // Alias -> 2
 ```
 
 ### No stringification

--- a/hashmap.js
+++ b/hashmap.js
@@ -110,7 +110,7 @@
 			return entries;
 		},
 
-
+		// TODO: This is deprecated and will be deleted in a future version
 		count:function() {
 			return this.size;
 		},

--- a/hashmap.js
+++ b/hashmap.js
@@ -42,7 +42,7 @@
 			// Store original key as well (for iteration)
 			var hash = this.hash(key);
 			if ( !(hash in this._data) ) {
-				this._count++;
+				this.size++;
 			}
 			this._data[hash] = [key, value];
 		},
@@ -54,7 +54,7 @@
 		copy:function(other) {
 			for (var hash in other._data) {
 				if ( !(hash in this._data) ) {
-					this._count++;
+					this.size++;
 				}
 				this._data[hash] = other._data[hash];
 			}
@@ -77,7 +77,7 @@
 		remove:function(key) {
 			var hash = this.hash(key);
 			if ( hash in this._data ) {
-				this._count--;
+				this.size--;
 				delete this._data[hash];
 			}
 		},
@@ -112,13 +112,13 @@
 
 
 		count:function() {
-			return this._count;
+			return this.size;
 		},
 
 		clear:function() {
 			// TODO: Would Object.create(null) make any difference
 			this._data = {};
-			this._count = 0;
+			this.size = 0;
 		},
 
 		clone:function() {

--- a/test/test.js
+++ b/test/test.js
@@ -305,26 +305,32 @@ describe('hashmap', function() {
 		});
 	});
 
-	describe('hashmap.count()', function() {
+	describe('hashmap.count() and hashmap.size', function() {
+		// NOTE: count() is expected to return .size, this
+		//   will be checked only in this unit test!
 		it('should return 0 when nothing was added', function() {
 			expect(hashmap.count()).to.equal(0);
+			expect(hashmap.size).to.equal(0);
 		});
 
 		it('should return 1 once an entry was added', function() {
 			hashmap.set('key', 'value');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 		});
 
 		it('should not increase when setting an existing key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key', 'value2');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 		});
 
 		it('should increase when setting different key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value2');
 			expect(hashmap.count()).to.equal(2);
+			expect(hashmap.size).to.equal(2);
 		});
 
 		it('should decrease when removing a key', function() {
@@ -332,9 +338,11 @@ describe('hashmap', function() {
 			hashmap.set('key2', 'value');
 			hashmap.remove('key');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 
 			hashmap.remove('key2');
 			expect(hashmap.count()).to.equal(0);
+			expect(hashmap.size).to.equal(0);
 		});
 	});
 


### PR DESCRIPTION
As discussed in https://github.com/flesler/hashmap/pull/34 .
This was easier than expected, as I only had to rename `._count` to `.size`.

This will break backwards compatibility with code that uses the `_count` property, but as this property is 
declared as hidden (via `_`) and not documented and also directly available via `count()`, I can see no reason why we can't change the name.