### PR TITLE
ES6 map compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,8 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
 - `entries() : Array<[*,*]>` returns an array with [key,value] pairs
-- `count() : Number` returns the amount of key-value pairs
+- `size : Number` the amount of key-value pairs
+- `count() : Number` returns the amount of key-value pairs *(deprecated)*
 - `clear() : HashMap` removes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original
 - `hash(key:*) : String` returns the stringified version of a key (used internally)
@@ -76,6 +77,16 @@ var HashMap = require('hashmap');
 map.set("some_key", "some value");
 map.get("some_key"); // --> "some value"
 ```
+
+### Map size / number of elements
+
+```js
+var map = new HashMap();
+map.set("key1", "val1");
+map.set("key2", "val2");
+map.size; // -> 2
+```
+
 ### No stringification
 
 ```js

--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 ## HashMap constructor overloads
 - `new HashMap()` creates an empty hashmap
 - `new HashMap(map:HashMap)` creates a hashmap with the key-value pairs of `map`
+- `new HashMap(arr:Array)` creates a hashmap from the 2D key-value array `arr`, e.g. `[['key1','val1'], ['key2','val2']]`
 - `new HashMap(key:*, value:*, key2:*, value2:*, ...)` creates a hashmap with several key-value pairs
 
 ## HashMap methods

--- a/Readme.md
+++ b/Readme.md
@@ -41,14 +41,15 @@ Unlike regular objects, __keys will not be stringified__. For example numbers an
 - `copy(other:HashMap) : HashMap` copies all key-value pairs from other to this instance
 - `has(key:*) : Boolean` returns whether a key is set on the hashmap
 - `search(value:*) : *` returns key under which given value is stored (`null` if not found)
-- `remove(key:*) : HashMap` deletes a key-value pair by key
+- `delete(key:*) : HashMap` deletes a key-value pair by key
+- `remove(key:*) : HashMap` Alias for `delete(key:*)` *(deprecated)*
 - `type(key:*) : String` returns the data type of the provided key (used internally)
 - `keys() : Array<*>` returns an array with all the registered keys
 - `values() : Array<*>` returns an array with all the values
 - `entries() : Array<[*,*]>` returns an array with [key,value] pairs
 - `size : Number` the amount of key-value pairs
 - `count() : Number` returns the amount of key-value pairs *(deprecated)*
-- `clear() : HashMap` removes all the key-value pairs on the hashmap
+- `clear() : HashMap` deletes all the key-value pairs on the hashmap
 - `clone() : HashMap` creates a new hashmap with all the key-value pairs of the original
 - `hash(key:*) : String` returns the stringified version of a key (used internally)
 - `forEach(function(value, key)) : HashMap` iterates the pairs and calls the function for each one
@@ -85,6 +86,14 @@ var map = new HashMap();
 map.set("key1", "val1");
 map.set("key2", "val2");
 map.size; // -> 2
+```
+
+### Deleting key-value pairs
+
+```js
+map.set("some_key", "some value");
+map.delete("some_key");
+map.get("some_key"); // --> undefined
 ```
 
 ### No stringification

--- a/hashmap.js
+++ b/hashmap.js
@@ -25,7 +25,15 @@
 		this.clear();
 		switch (arguments.length) {
 			case 0: break;
-			case 1: this.copy(other); break;
+			case 1: {
+				if ('length' in other) {
+					// Flatten 2D array to alternating key-value array
+					multi(this, Array.prototype.concat.apply([], other));
+				} else { // Assumed to be a HashMap instance
+					this.copy(other);
+				}
+				break;
+			}
 			default: multi(this, arguments); break;
 		}
 	}

--- a/hashmap.js
+++ b/hashmap.js
@@ -50,7 +50,7 @@
 			// Store original key as well (for iteration)
 			var hash = this.hash(key);
 			if ( !(hash in this._data) ) {
-				this._count++;
+				this.size++;
 			}
 			this._data[hash] = [key, value];
 		},
@@ -62,7 +62,7 @@
 		copy:function(other) {
 			for (var hash in other._data) {
 				if ( !(hash in this._data) ) {
-					this._count++;
+					this.size++;
 				}
 				this._data[hash] = other._data[hash];
 			}
@@ -85,7 +85,7 @@
 		remove:function(key) {
 			var hash = this.hash(key);
 			if ( hash in this._data ) {
-				this._count--;
+				this.size--;
 				delete this._data[hash];
 			}
 		},
@@ -118,15 +118,15 @@
 			return entries;
 		},
 
-
+		// TODO: This is deprecated and will be deleted in a future version
 		count:function() {
-			return this._count;
+			return this.size;
 		},
 
 		clear:function() {
 			// TODO: Would Object.create(null) make any difference
 			this._data = {};
-			this._count = 0;
+			this.size = 0;
 		},
 
 		clone:function() {

--- a/hashmap.js
+++ b/hashmap.js
@@ -82,7 +82,7 @@
 			return null;
 		},
 
-		remove:function(key) {
+		delete:function(key) {
 			var hash = this.hash(key);
 			if ( hash in this._data ) {
 				this.size--;
@@ -178,13 +178,18 @@
 
 	//- Add chaining to all methods that don't return something
 
-	['set','multi','copy','remove','clear','forEach'].forEach(function(method) {
+	['set','multi','copy','delete','clear','forEach'].forEach(function(method) {
 		var fn = proto[method];
 		proto[method] = function() {
 			fn.apply(this, arguments);
 			return this;
 		};
 	});
+
+	//- Backwards compatibility
+
+	// TODO: remove() is deprecated and will be deleted in a future version
+	HashMap.prototype.remove = HashMap.prototype.delete;
 
 	//- Utils
 

--- a/test/test.js
+++ b/test/test.js
@@ -305,26 +305,32 @@ describe('hashmap', function() {
 		});
 	});
 
-	describe('hashmap.count()', function() {
+	describe('hashmap.count() and hashmap.size', function() {
+		// NOTE: count() is expected to return .size, this
+		//   will be checked only in this unit test!
 		it('should return 0 when nothing was added', function() {
 			expect(hashmap.count()).to.equal(0);
+			expect(hashmap.size).to.equal(0);
 		});
 
 		it('should return 1 once an entry was added', function() {
 			hashmap.set('key', 'value');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 		});
 
 		it('should not increase when setting an existing key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key', 'value2');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 		});
 
 		it('should increase when setting different key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value2');
 			expect(hashmap.count()).to.equal(2);
+			expect(hashmap.size).to.equal(2);
 		});
 
 		it('should decrease when removing a key', function() {
@@ -332,9 +338,11 @@ describe('hashmap', function() {
 			hashmap.set('key2', 'value');
 			hashmap.remove('key');
 			expect(hashmap.count()).to.equal(1);
+			expect(hashmap.size).to.equal(1);
 
 			hashmap.remove('key2');
 			expect(hashmap.count()).to.equal(0);
+			expect(hashmap.size).to.equal(0);
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -441,6 +441,26 @@ describe('hashmap', function() {
 			expect(map.get('key2')).to.equal('value2');
 		});
 
+		it('should initialize from a 2D array for a single Array argument', function() {
+			var map = new HashMap(
+				[['key', 'value'],
+				 ['key2', 'value2']]
+			);
+			expect(map.count()).to.equal(2);
+			expect(map.get('key')).to.equal('value');
+			expect(map.get('key2')).to.equal('value2');
+		});
+
+		it('should initialize from a 2D array for a nested Array argument', function() {
+			var map = new HashMap(
+				[[[1, 'key'], ['value', 1]],
+				 [[2, 'key2'], ['value2', 2]]]
+			);
+			expect(map.count()).to.equal(2);
+			expect(map.get([1, 'key'])).to.deep.equal(['value', 1]);
+			expect(map.get([2, 'key2'])).to.deep.equal(['value2', 2]);
+		});
+
 		it('should initialize with pairs when several arguments', function() {
 			var map = new HashMap(
 				'key', 'value',

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,7 @@ describe('hashmap', function() {
 		it('should return the instance on some methods', function() {
 			expect(hashmap.set('key', 'value')).to.equal(hashmap);
 			expect(hashmap.multi()).to.equal(hashmap);
+			expect(hashmap.delete('key')).to.equal(hashmap);
 			expect(hashmap.remove('key')).to.equal(hashmap);
 			expect(hashmap.copy(hashmap)).to.equal(hashmap);
 			expect(hashmap.clear()).to.equal(hashmap);
@@ -127,16 +128,22 @@ describe('hashmap', function() {
 		});
 	});
 
-	describe('hashmap.remove()', function() {
-		it('should remove an entry by key', function() {
+	describe('hashmap.delete()', function() {
+		it('should delete an entry by key', function() {
 			hashmap.set('key', 'value1');
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(hashmap.has('key')).to.be.false;
 		});
 
 		it('should not fail when the key is not found', function() {
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(hashmap.has('key')).to.be.false;
+		});
+	});
+
+	describe('hashmap.remove()', function() {
+		it('should be the same function as delete', function() {
+			expect(hashmap.remove).to.equal(hashmap.delete);
 		});
 	});
 
@@ -233,9 +240,9 @@ describe('hashmap', function() {
 			expect(collect().length).to.equal(2);
 		});
 
-		it('should not call the callback on removed keys', function() {
+		it('should not call the callback on delete keys', function() {
 			hashmap.set('key', 'value');
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(collect()).to.be.empty;
 		});
 
@@ -333,14 +340,14 @@ describe('hashmap', function() {
 			expect(hashmap.size).to.equal(2);
 		});
 
-		it('should decrease when removing a key', function() {
+		it('should decrease when deleting a key', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value');
-			hashmap.remove('key');
+			hashmap.delete('key');
 			expect(hashmap.count()).to.equal(1);
 			expect(hashmap.size).to.equal(1);
 
-			hashmap.remove('key2');
+			hashmap.delete('key2');
 			expect(hashmap.count()).to.equal(0);
 			expect(hashmap.size).to.equal(0);
 		});
@@ -352,13 +359,13 @@ describe('hashmap', function() {
 			expect(hashmap.count()).to.equal(0);
 		});
 
-		it('should remove the only entry', function() {
+		it('should delete the only entry', function() {
 			hashmap.set('key', 'value');
 			hashmap.clear();
 			expect(hashmap.count()).to.equal(0);
 		});
 
-		it('should remove multiple entries', function() {
+		it('should delete multiple entries', function() {
 			hashmap.set('key', 'value');
 			hashmap.set('key2', 'value2');
 			hashmap.clear();


### PR DESCRIPTION
This is a merge of https://github.com/flesler/hashmap/pull/36, https://github.com/flesler/hashmap/pull/35 and https://github.com/flesler/hashmap/pull/34 and provides better compatibility to ES6 Maps by:
* Adding a constructor that works on 2D key-value pair arrays
* Renaming `remove()` to `delete()` and deprecating `remove()`
* Adding `.size` member (by renaming `_count`) and deprecating `count()`