### PR TITLE
Fix for use strict

### DIFF
--- a/hashmap.js
+++ b/hashmap.js
@@ -5,7 +5,7 @@
  * Homepage: https://github.com/flesler/hashmap
  */
 
-(function(factory) {
+(function(factory, scope) {
 	if (typeof define === 'function' && define.amd) {
 		// AMD. Register as an anonymous module.
 		define([], factory);
@@ -16,7 +16,7 @@
 		HashMap.HashMap = HashMap;
 	} else {
 		// Browser globals (this is window)
-		this.HashMap = factory();
+		scope.HashMap = factory();
 	}
 }(function() {
 
@@ -206,4 +206,4 @@
 	}
 
 	return HashMap;
-}));
+}, typeof window === 'object' && window.window === window && window));


### PR DESCRIPTION
Inside the final else of the loader section of Hashmap is an innocuous error if 'use strict' is ever added.

``` js
	} else {
		// Browser globals (this is window)
		this.HashMap = factory();
	}
```
With 'use strict' the IIFE actually has no `this` variable because it is not called via bind/apply. Clearly this was meant as the final fallback to load Hashmap into the global namespace (window) when neither requirejs or amd are used. In a non-strict environment it would do just that, this === window, but with strict we don't get that luxury.

The code to discover "global" is from: https://github.com/purposeindustries/window-or-global/blob/master/lib/index.js
Which technically finds either window/self (browser) or global (node).

I only noticed this problem after running hashmap through a minifier, wherein it also added 'use struct'. I left my fix as optional as possible, so your code flow is unchanged unless `this` becomes falsey.

I know you aren't using 'use struct' in the project, but it would make it simpler for others if they concat/minify and 'use struct' ever gets added in.

