### PR TITLE
ES6 iterators

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,11 @@ map
   .forEach(function(value, key) {
       console.log(key + " : " + value);
   });
+
+// ES6 Iterators
+for (const pair of map) {
+    console.log(`${pair.key} : ${pair.value}`)
+}
 ```
 
 ## LICENSE

--- a/hashmap.js
+++ b/hashmap.js
@@ -175,6 +175,24 @@
 
 	HashMap.uid = 0;
 
+	// Iterator protocol for ES6
+	if (typeof Symbol !== 'undefined' && typeof Symbol.iterator !== 'undefined') {
+		proto[Symbol.iterator] = function() {
+			var entries = this.entries();
+			var i = 0;
+			return {
+				next:function() {
+					if (i === entries.length) { return { done: true }; }
+					var currentEntry = entries[i++];
+					return {
+						value: { key: currentEntry[0], value: currentEntry[1] },
+						done: false
+					};
+				}
+			};
+		};
+	}
+
 	//- Add chaining to all methods that don't return something
 
 	['set','multi','copy','delete','clear','forEach'].forEach(function(method) {

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,33 @@ describe('hashmap', function() {
 		});
 	});
 
+	describe('ES6 Iterators', function() {
+		it('should do nothing on an empty hashmap', function() {
+			var called = false;
+			for (var pair of hashmap) { // jshint ignore:line
+				// (`pair` is not used)
+				called = true;
+			}
+			expect(called).to.be.false;
+		});
+
+		it('should iterate over all entries exactly once', function() {
+			// Since order of iteration is not guaranteed, we'll keep track of which key-value pair has been checked, and how many times.
+			var numberOfTries = 10;
+			var calls = new Array(numberOfTries).fill(0);
+			// Populate hashmap with ['keyI': I] pairs
+			for (var i = 0; i < numberOfTries; i++) {
+				hashmap.set('key' + i, i);
+			}
+			// Perform ES6 iteration
+			for (var pair of hashmap) {
+				expect(pair.key).to.equal('key' + pair.value);
+				calls[pair.value]++;
+			}
+			expect(calls).to.deep.equal(new Array(numberOfTries).fill(1));
+		});
+	});
+
 	describe('hashmap.count() and hashmap.size', function() {
 		// NOTE: count() is expected to return .size, this
 		// will be checked only in this unit test!


### PR DESCRIPTION
Adds support for the [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) in ES6.